### PR TITLE
Refactor pipeline generalization

### DIFF
--- a/assets/readme.md
+++ b/assets/readme.md
@@ -6,5 +6,5 @@
 2. Download the MSD Lung Tumor dataset from [here](https://drive.google.com/drive/folders/1HqEgzS8BV2c7xYNrZdEAnrHk7osJJ--2).
 3. Extract the zip file into `/assets/`.
 4. Run `synthlung format --dataset msd` to adjust dataset format
-5. Run `synthlung seed --dataset msd` to extract tumor seeds from the dataset
+5. Run `synthlung seed --dataset` to extract tumor seeds from the dataset
 6. Run `synthlung host --dataset msd` to extract lung masks from the images

--- a/synthlung/__main__.py
+++ b/synthlung/__main__.py
@@ -6,14 +6,14 @@ from synthlung.utils.lung_segmentation_pipeline import LungMaskPipeline, HostJso
 from lungmask import LMInferer
 import json
 
-def seed_msd():
-    json_file_path = "./assets/source/msd/dataset.json"
+def seed():
+    json_file_path = "./assets/source/dataset.json"
 
     with open(json_file_path, 'r') as json_file:
         image_dict = json.load(json_file)
     crop_pipeline = TumorCropPipeline()
     crop_pipeline(image_dict)
-    formatter = MSDGenerateJSONFormatter("./assets/seeds/msd/")
+    formatter = MSDGenerateJSONFormatter("./assets/seeds/")
     formatter.generate_json()
 
 def format_msd():
@@ -55,8 +55,7 @@ def main():
         if(args.dataset == "msd"):
             format_msd()
     elif args.action == "seed":
-        if(args.dataset == "msd"):
-            seed_msd()
+        seed()
     elif args.action == "generate":
         if(args.dataset == "msd"):
             generate_randomized_tumors()

--- a/synthlung/utils/dataset_formatter.py
+++ b/synthlung/utils/dataset_formatter.py
@@ -9,7 +9,7 @@ IMAGE_NII_GZ = 'image.nii.gz'
 LABEL_NII_GZ = 'label.nii.gz'
 
 class MSDImageSourceFormatter(ImageSourceFormatter, JSONGenerator):
-    def __init__(self, source_directory: str = "./assets/Task06_Lung/", target_directory: str = "./assets/source/msd/") -> None:
+    def __init__(self, source_directory: str = "./assets/Task06_Lung/", target_directory: str = "./assets/source/") -> None:
         self.target_directory = target_directory
         self.source_directory = source_directory
 

--- a/synthlung/utils/tumor_isolation_pipeline.py
+++ b/synthlung/utils/tumor_isolation_pipeline.py
@@ -70,8 +70,8 @@ class TumorCropPipeline(object):
             LoadImaged(keys=['image', 'label'], image_only = False),
             TumorSeedIsolationd(image_key='image', label_key='label', image_output_key='seed_image', label_output_key='seed_label'),
             RenameSourceToSeed(meta_dict_keys=['seed_image_meta_dict', 'seed_label_meta_dict']),
-            SaveImaged(keys=['seed_image'], output_dir='./assets/seeds/msd/', output_postfix='', separate_folder=False),
-            SaveImaged(keys=['seed_label'], output_dir='./assets/seeds/msd/', output_postfix='', separate_folder=False)
+            SaveImaged(keys=['seed_image'], output_dir='./assets/seeds/', output_postfix='', separate_folder=False),
+            SaveImaged(keys=['seed_label'], output_dir='./assets/seeds/', output_postfix='', separate_folder=False)
         ])
     
     def __call__(self, image_dict) -> None:


### PR DESCRIPTION
## Pull Request

### Description
<!Please provide a brief description of the changes you've made in this pull request.!>
Small adjustments to the Tumor Isolation Pipeline and the folderstructure of assets

- Generalize the TumorIsolation-transform so it can be used in Compose() without the need to temporarily store files on disk in between transforms
- Place formatted images directly into /assets/source/ rather than in specific dataset folder (/assets/source/msd/)
- Place seed images directly into /assets/seeds/ rather than in specific dataset folder (/assets/seeds/msd/)


### Type of Change
<!Please select the relevant option by placing an "x" in the [ ].!>

- [ ] Bug Fix
- [ ] New Feature
- [ ] Documentation Update
- [x] Code Refactoring
- [ ] Other (please describe)

### Checklist
<!Before submitting this pull request, please make sure you have done the following:!>

- [x] I have reviewed the code to ensure it follows the project's coding standards.
- [x] I have tested the changes locally to verify that they work as expected.
- [ ] I have updated the documentation if necessary.

### Screenshots
<!If your changes include any visible changes or new features, please add screenshots here.!>
